### PR TITLE
urlencode using perl for the message.

### DIFF
--- a/hipchat_room_message
+++ b/hipchat_room_message
@@ -67,7 +67,6 @@ INPUT=$(echo -n "${INPUT}" | sed "s/$/<br \/>/")
 # urlescape with perl
 INPUT=$(echo -n "${INPUT}" | perl -p -e 's/([^A-Za-z0-9])/sprintf("%%%02X", ord($1))/seg')
 
-
 # do the curl
 curl -sS \
   -d "auth_token=$TOKEN&room_id=$ROOM_ID&from=$FROM&color=$COLOR&message=$INPUT&notify=$NOTIFY" \


### PR DESCRIPTION
Trying to send links I found that the & character was causing some problems.

We (Eric & Me) worked around it writing escaped characters but... if you want and adding perl as a dependency... special chars can be escaped.

I hope you find it as useful as we did.

Javier.
