### PR TITLE
Only replace bare URLs with HTML links.

### DIFF
--- a/hipchat_room_message
+++ b/hipchat_room_message
@@ -67,8 +67,8 @@ INPUT=$(cat)
 # replace newlines with XHTML <br />
 INPUT=$(echo -n "${INPUT}" | sed "s/$/<br \/>/")
 
-# replace URLs with real hyperlinks - (revised to allow mutiple URL matches) - c3w
-INPUT=$(echo -n "${INPUT}" | sed "s/\([a-zA-Z]*\:\/\/[^ ]*\)/\<a href=\"\1\"\>\1\<\/a>/g")
+# replace bare URLs with real hyperlinks
+INPUT=$(echo -n "${INPUT}" | perl -p -e "s/(?<!href=\")((?:https?|ftp|mailto)\:\/\/[^ ]*)/\<a href=\"\1\"\>\1\<\/a>/g")
 
 # urlencode with perl
 INPUT=$(echo -n "${INPUT}" | perl -p -e 's/([^A-Za-z0-9])/sprintf("%%%02X", ord($1))/seg')


### PR DESCRIPTION
The previous URL-matching regular expression would also operate on
URLs within existing HTML anchor tags, resulting in broken markup.

To do this, we use the more advanced (?<!a)b "lookbehind" syntax.
sed doesn't support that so we need to use Perl instead.
