### PR TITLE
fixed newline regex so that 'real hyperlinks' regex works properly.  als...

### DIFF
--- a/hipchat_room_message
+++ b/hipchat_room_message
@@ -64,11 +64,11 @@ fi
 # read stdin
 INPUT=$(cat)
 
-# replace newlines with XHTML <br />
-INPUT=$(echo -n "${INPUT}" | sed "s/$/<br \/>/")
+# replace newlines with XHTML <br>
+INPUT=$(echo -n "${INPUT}" | sed "s/$/\<br\>/")
 
 # replace bare URLs with real hyperlinks
-INPUT=$(echo -n "${INPUT}" | perl -p -e "s/(?<!href=\")((?:https?|ftp|mailto)\:\/\/[^ ]*)/\<a href=\"\1\"\>\1\<\/a>/g")
+INPUT=$(echo -n "${INPUT}" | perl -p -e "s/(?<!href=\")((?:https?|ftp|mailto)\:\/\/[^ \n]*)/\<a href=\"\1\"\>\1\<\/a>/g")
 
 # urlencode with perl
 INPUT=$(echo -n "${INPUT}" | perl -p -e 's/([^A-Za-z0-9])/sprintf("%%%02X", ord($1))/seg')


### PR DESCRIPTION
...o add 'end of hyperlink regex matching' to include newline as well as spaces
