### PR TITLE
urlencode message only if API version is v1

### DIFF
--- a/hipchat_room_message
+++ b/hipchat_room_message
@@ -106,7 +106,9 @@ fi
 INPUT=$(echo -n "${INPUT}" | perl -p -e "s/(?<!href=\"|href=')((?:https?|ftp|mailto)\:\/\/[^ \n]*)/\<a href=\"\1\"\>\1\<\/a>/g")
 
 # urlencode with perl
-INPUT=$(echo -n "${INPUT}" | perl -p -e 's/([^A-Za-z0-9])/sprintf("%%%02X", ord($1))/seg')
+if [ $API == 'v1' ]; then
+  INPUT=$(echo -n "${INPUT}" | perl -p -e 's/([^A-Za-z0-9])/sprintf("%%%02X", ord($1))/seg')
+fi
 
 # replace notification boolean from 1/0 to 'true'/'false' for API v2
 if [ $API == 'v2' ]; then


### PR DESCRIPTION
In API v2, we send data as JSON, so I think we don't have to urlencode message.
This PR skip urlencoding if API version is not v1.
