### PR TITLE
Explicit warnings for missing arguments

### DIFF
--- a/hipchat_room_message
+++ b/hipchat_room_message
@@ -71,6 +71,15 @@ done
 
 # check for required args
 if [[ -z $TOKEN ]] || [[ -z $ROOM_ID ]] || [[ -z $FROM ]]; then
+  if [[ -z $TOKEN ]]; then
+    echo "$(basename $0): missing TOKEN"
+  fi
+  if [[ -z $ROOM_ID ]]; then
+    echo "$(basename $0): missing ROOM_ID"
+  fi
+  if [[ -z $FROM ]]; then
+    echo "$(basename $0): missing FROM"
+  fi
   usage
   exit 1
 fi


### PR DESCRIPTION
When using a mix of a config file and command line options, it's helpful to hint at which arguments are missing.
