### PR TITLE
removes newline from the message

### DIFF
--- a/hipchat_room_message
+++ b/hipchat_room_message
@@ -99,7 +99,7 @@ fi
 
 # replace newlines with XHTML <br>
 if [ $FORMAT == 'html' ]; then
-    INPUT=$(echo -n "${INPUT}" | sed "s/$/\<br\>/")
+    INPUT=$(echo -n "${INPUT}" | sed "s/$/\<br\>/" | tr -d '\r\n')
 fi
 
 # replace bare URLs with real hyperlinks


### PR DESCRIPTION
Hi,
I've noticed that an HTML multiline message will be rejected beacuse it will produce a wrang JSON object.

You are appending `<br/>` at the end of each lines but not removing the `\n`

This small fix will removes all the `\n` and `\r` in the message before sending it.

I've tested it on OS X 10.9 and CentOS 7
