### PR TITLE
fixes -n -n when sending from macs; Highlights -i message in help; adds ~/.hipchat 

### DIFF
--- a/hipchat_room_message
+++ b/hipchat_room_message
@@ -43,7 +43,7 @@ EOF
 
 # Include hipchat defaults if available
 test -f /etc/hipchat && . /etc/hipchat
-test -f ~/.hipchat && .~/.hipchat
+test -f ~/.hipchat && . ~/.hipchat
 
 TOKEN=${HIPCHAT_TOKEN:-}
 ROOM_ID=${HIPCHAT_ROOM_ID:-}

--- a/hipchat_room_message
+++ b/hipchat_room_message
@@ -16,13 +16,15 @@
 
 # exit on failure
 set -e
+# http://apple.stackexchange.com/questions/68684/why-sh-c-echo-n-1-is-different-from-bash-c-echo-n-1
+shopt -u xpg_echo
 
 usage() {
   cat << EOF
 Usage: $0 -t <token> -r <room id> -f <from name>
 
 This script will read from stdin and send the contents to the given room as
-a system message.
+a system message. Or use -i message.
 
 OPTIONS:
    -h             Show this message
@@ -41,6 +43,7 @@ EOF
 
 # Include hipchat defaults if available
 test -f /etc/hipchat && . /etc/hipchat
+test -f ~/.hipchat && .~/.hipchat
 
 TOKEN=${HIPCHAT_TOKEN:-}
 ROOM_ID=${HIPCHAT_ROOM_ID:-}


### PR DESCRIPTION
Mac's echo doesn't do -n resulting in messages like:
![monosnap 2015-01-04 11-55-40](https://cloud.githubusercontent.com/assets/59202/5606700/9f50f628-9408-11e4-9028-3e88c653963f.png)

The attached pull request fixes that.

Also adds support for a ~/.hipchat 
