### PR TITLE
Send Auth Token in Header instead of URL parameter

### DIFF
--- a/hipchat_room_message
+++ b/hipchat_room_message
@@ -123,8 +123,9 @@ fi
 if [ $API == 'v2' ]; then
   curl -sS \
     -H 'Content-type: application/json' \
+    -H "Authorization: Bearer $TOKEN" \
     -d "{\"color\":\"$COLOR\", \"message\":\"$INPUT\", \"message_format\":\"$FORMAT\", \"notify\":$NOTIFY}" \
-    https://$HOST/v2/room/$ROOM_ID/notification?auth_token=$TOKEN
+    https://$HOST/v2/room/$ROOM_ID/notification
 else
   curl -sS \
     -d "auth_token=$TOKEN&room_id=$ROOM_ID&from=$FROM&color=$COLOR&message_format=$FORMAT&message=$INPUT&notify=$NOTIFY" \


### PR DESCRIPTION
To avoid persisting the user's authentication token in server log files, the token should be transmitted as HTTP header instead of URL parameter while using HipChat API v2.
