### PR TITLE
Supports multiple lines

### DIFF
--- a/hipchat_room_message
+++ b/hipchat_room_message
@@ -99,7 +99,7 @@ fi
 
 # replace newlines with XHTML <br>
 if [ $FORMAT == 'html' ]; then
-    INPUT=$(echo -n "${INPUT}" | sed "s/$/\<br\>/")
+    INPUT=$(echo -n "${INPUT}" | perl -p -e 's/\n/<br \/>/')
 fi
 
 # replace bare URLs with real hyperlinks


### PR DESCRIPTION
hipchat_room_message fails to send a text that including multiple lines like this:

  ( echo line1 ; echo line2 ) | /usr/local/bin/hipchat_room_message -v v2 -r "${HIPCHAT_ROOM}" -t "${HIPCHAT_TOKEN}" -f "$HOSTNAME"

This change supports such a message.
