### PR TITLE
Support images by not rewriting URLs after src=

### DIFF
--- a/hipchat_room_message
+++ b/hipchat_room_message
@@ -121,7 +121,7 @@ if [ $FORMAT == 'html' ]; then
 fi
 
 # replace bare URLs with real hyperlinks
-INPUT=$(echo -n "${INPUT}" | perl -p -e "s/(?<!href=\"|href=')((?:https?|ftp|mailto)\:\/\/[^ \n]*)/\<a href=\"\1\"\>\1\<\/a>/g")
+INPUT=$(echo -n "${INPUT}" | perl -p -e "s/(?<!href=\"|href='| src=\"| src=')((?:https?|ftp|mailto)\:\/\/[^ \n]*)/\<a href=\"\1\"\>\1\<\/a>/g")
 
 # urlencode with perl
 if [ $API == 'v1' ]; then


### PR DESCRIPTION
This PR extends the negative look-behind expression to avoid rewriting URLs into `<a>` tags when they occur after `src=`.  This allows images to work correctly.

Fixes #20 

```
(echo 'hello kitty...' ; echo '<img width="100" src="https://www.petdrugsonline.co.uk/images/page-headers/cats-master-header">') | ./hipchat_room_message -c gray
```
![kitty](https://cloud.githubusercontent.com/assets/1017053/23798034/55b056e8-0568-11e7-904b-262d5134dfa8.png)
